### PR TITLE
Make the environment variable names what the README.md says they are

### DIFF
--- a/pb_app/lib/config.dart
+++ b/pb_app/lib/config.dart
@@ -6,6 +6,6 @@ class Config {
 
   static const skipLogin = true;
 
-  static const testEmail = String.fromEnvironment('testEmail');
-  static const testPassword = String.fromEnvironment('testPassword');
+  static const testEmail = String.fromEnvironment('PBF_TEST_EMAIL');
+  static const testPassword = String.fromEnvironment('PBF_TEST_PASSWORD');
 }


### PR DESCRIPTION
Currently, config.dart tries to read "testEmail" and "testPassword", which according to the README.md, are the _values_, not the keys