### PR TITLE
Move submissions into state and out of the widget

### DIFF
--- a/pb_app/lib/models/submission_form_state.dart
+++ b/pb_app/lib/models/submission_form_state.dart
@@ -4,6 +4,11 @@ import 'package:flutter/material.dart' show Colors;
 import 'package:flutter/widgets.dart';
 import 'package:palette_generator/palette_generator.dart';
 
+enum ScreenshotSubmissionLocations {
+  home,
+  lock,
+}
+
 class SubmissionFormState extends ChangeNotifier {
   Color? _card1Dominant;
   Color _selectedBackgroundColor = Colors.white;
@@ -13,9 +18,34 @@ class SubmissionFormState extends ChangeNotifier {
   bool get isLightBackground =>
       _selectedBackgroundColor.computeLuminance() > 0.5;
 
+  File? _homescreenImage;
+  File? _lockscreenImage;
+
+  File? get homeScreenImage => _homescreenImage;
+  File? get lockscreenImage => _lockscreenImage;
+
   SubmissionFormState();
 
-  void setCard1Image(File image) async {
+  void setSelectedCardImage(
+    File image,
+    ScreenshotSubmissionLocations screen,
+  ) {
+    if (screen == ScreenshotSubmissionLocations.home) {
+      _homescreenImage = image;
+    } else if (screen == ScreenshotSubmissionLocations.lock) {
+      _lockscreenImage = image;
+    }
+
+    notifyListeners();
+  }
+
+  void setCardImage(
+    File image,
+    ScreenshotSubmissionLocations screen,
+  ) async {
+    //Set the selected card background first, generating a palette has a delay
+    setSelectedCardImage(image, screen);
+
     final palette = await PaletteGenerator.fromImageProvider(FileImage(image));
     _card1Dominant = palette.dominantColor?.color;
     final Color pastelTone;

--- a/pb_app/lib/submission_form.dart
+++ b/pb_app/lib/submission_form.dart
@@ -115,8 +115,8 @@ class _UploadPageScaffoldState extends State<UploadPageScaffold> {
             ),
             clipBehavior: Clip.none,
             children: const [
-              _Card('Home Screen'),
-              _Card('Lock Screen'),
+              _Card(ScreenshotSubmissionLocations.home),
+              _Card(ScreenshotSubmissionLocations.lock),
             ],
           );
         }),
@@ -138,19 +138,33 @@ class _UploadPageScaffoldState extends State<UploadPageScaffold> {
 }
 
 class _Card extends StatefulWidget {
-  const _Card(this.title);
+  const _Card(this.screen);
 
-  final String title;
+  final ScreenshotSubmissionLocations screen;
 
   @override
   State<_Card> createState() => _CardState();
 }
 
 class _CardState extends State<_Card> {
-  File? image;
-
   @override
   Widget build(BuildContext context) {
+    //Is this card submitting a lock screen or a home screen?
+    final cardType = widget.screen;
+
+    final homescreenImage =
+        context.select((SubmissionFormState state) => state.homeScreenImage);
+    final lockscreenImage =
+        context.select((SubmissionFormState state) => state.lockscreenImage);
+
+    File? image;
+
+    if (cardType == ScreenshotSubmissionLocations.home) {
+      image = homescreenImage;
+    } else if (cardType == ScreenshotSubmissionLocations.lock) {
+      image = lockscreenImage;
+    }
+
     return Center(
       child: AspectRatio(
         aspectRatio: _kPhotoAspectRatio,
@@ -165,10 +179,10 @@ class _CardState extends State<_Card> {
                 final xfile =
                     await ImagePicker().pickImage(source: ImageSource.gallery);
                 if (xfile == null || !mounted) return;
-                setState(() {
-                  image = File(xfile.path);
-                });
-                context.read<SubmissionFormState>().setCard1Image(image!);
+                context.read<SubmissionFormState>().setCardImage(
+                      File(xfile.path),
+                      cardType,
+                    );
               } catch (e) {
                 if (kDebugMode && mounted) {
                   ToastProvider.of(context).showToast(e.toString());
@@ -188,7 +202,7 @@ class _CardState extends State<_Card> {
                     )),
                     image: image != null
                         ? DecorationImage(
-                            image: FileImage(image!),
+                            image: FileImage(image),
                             fit: BoxFit.cover,
                           )
                         : null,
@@ -220,7 +234,7 @@ class _CardState extends State<_Card> {
                       borderRadius: platformAwareBorderRadius(99),
                     ),
                     child: Text(
-                      widget.title,
+                      cardType.toTitleString(),
                       style: const TextStyle(
                         color: Colors.white,
                         fontWeight: FontWeight.w500,

--- a/pb_app/lib/utils.dart
+++ b/pb_app/lib/utils.dart
@@ -4,6 +4,7 @@ import 'package:collection/collection.dart';
 import 'package:figma_squircle/figma_squircle.dart';
 import 'package:flutter/material.dart';
 import 'package:pb_app/config.dart';
+import 'package:pb_app/models/submission_form_state.dart';
 import 'package:pb_app/secrets.dart';
 import 'package:pocketbase/pocketbase.dart';
 
@@ -58,5 +59,11 @@ extension UserServiceX on UserService {
   Future<UserAuth> get authViaSecrets async {
     return UserService(client)
         .authViaEmail(Secrets.testEmail, Secrets.testPassword);
+  }
+}
+
+extension ScreenshotSubmissionLocationsX on ScreenshotSubmissionLocations {
+  String toTitleString() {
+    return '${name[0].toUpperCase()}${name.substring(1)} Screen';
   }
 }


### PR DESCRIPTION
This is _an_ approach to fix screenshot submissions from being lost when the _Card widget is disposed from the PageView (e.g. user scrolled one of the cards out of view)

I left the _Card widget as a stateful widget to avoid the  [async buildcontext gap](https://dart-lang.github.io/linter/lints/use_build_context_synchronously.html) lint. Once [this](https://github.com/flutter/flutter/pull/111619) makes it into flutter stable, we could make _Card stateless and check `context.mounted`. 

Depending on how #10 is handled, we may not wish to take this particular approach, but this will at least fix the bug. 
